### PR TITLE
Enable metrics Dash and NFT interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ npm install -g netlify-cli
 netlify dev
 
 ```
+
+## Additional scripts
+
+This repository includes optional Python utilities in `scripts/`.
+
+- **flask_nft_interface.py** – a Flask + Dash application for minting NFTs and visualizing vortex data. Environment variables configure Web3 and IPFS.
+- **MONSTERDOG_METRICS_ULTIMATE_TRIPLED.py** – merges local metric files, extracts Z-score anomalies, generates a PDF report, and launches a Dash dashboard to inspect results.
+
+Install the dependencies listed in each script and run them with Python 3.9+.

--- a/scripts/MONSTERDOG_METRICS_ULTIMATE_TRIPLED.py
+++ b/scripts/MONSTERDOG_METRICS_ULTIMATE_TRIPLED.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+MONSTERDOG_METRICS_ULTIMATE_TRIPLED
+Pipeline autonome : fusion métriques → Z-score → QR → PDF → Dash.
+"""
+
+import os, glob, json, time, webbrowser
+import numpy as np
+import pandas as pd
+from scipy import stats
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import A4
+import qrcode
+import dash, dash_table, dash_core_components as dcc, dash_html_components as html
+from dash.dependencies import Input, Output
+
+###############################################################################
+# 0. CONFIGURATION GLOBALE
+###############################################################################
+THRESHOLD_Z = 3.0          # σ-cut
+FREQ_SACREE = 11987.8589   # Hz pivot
+TS = time.strftime('%Y%m%d_%H%M%S')
+PDF_NAME = f"DECORTIFICUM_ANOMALIES_{TS}.pdf"
+
+###############################################################################
+# 1. INGESTION & FUSION
+###############################################################################
+def load_metrics(path='.', patterns=('*.csv', '*.xlsx')):
+    frames = []
+    for p in patterns:
+        for file in glob.glob(os.path.join(path, p)):
+            if file.endswith('.csv'):
+                frames.append(pd.read_csv(file))
+            else:
+                frames.append(pd.read_excel(file))
+    df = pd.concat(frames, ignore_index=True).infer_objects()
+    df.columns = [c.strip().lower() for c in df.columns]
+    df['timestamp'] = pd.Timestamp.utcnow()
+    return df
+
+###############################################################################
+# 2. ANOMALIE Z-SCORE
+###############################################################################
+def extract_anomalies(df, z=THRESHOLD_Z):
+    numeric = df.select_dtypes(include=np.number)
+    z_scores = np.abs(stats.zscore(numeric, nan_policy='omit'))
+    mask = (z_scores > z).any(axis=1)
+    anomalies = df.loc[mask]
+    anomalies.to_csv('anomalies.csv', index=False)
+    return anomalies
+
+###############################################################################
+# 3. SIGIL QR
+###############################################################################
+def make_qr(text, out_dir='qr_sigils'):
+    os.makedirs(out_dir, exist_ok=True)
+    filename = os.path.join(out_dir, f"sigil_{hash(text)}.png")
+    img = qrcode.make(text)
+    img.save(filename)
+    return filename
+
+###############################################################################
+# 4. EXPORT PDF RITUEL
+###############################################################################
+def build_pdf(anomalies, pdf_path=PDF_NAME):
+    c = canvas.Canvas(pdf_path, pagesize=A4)
+    width, height = A4
+
+    # Page de garde
+    c.setFont("Helvetica-Bold", 20)
+    c.drawCentredString(width/2, height-72, "MONSTERDOG – Rapport Décortificum")
+    c.setFont("Helvetica", 12)
+    c.drawString(72, height-100, f"Généré : {TS} | Freq sacrée : {FREQ_SACREE} Hz")
+    c.showPage()
+
+    # Tableau simplifié
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(72, height-72, "Anomalies détectées (Top 20)")
+    c.setFont("Helvetica", 10)
+    for i, row in anomalies.head(20).iterrows():
+        y = height-100 - 12*i
+        c.drawString(72, y, json.dumps(row.to_dict())[:95] + '…')
+    c.showPage()
+
+    # QR sigils
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(72, height-72, "Sigils QR (limités à 6)")
+    for i, row in anomalies.head(6).iterrows():
+        qr_path = make_qr(json.dumps(row.to_dict()))
+        c.drawImage(qr_path, 72 + (i%3)*160, height-200 - (i//3)*180, width=128, height=128)
+    c.save()
+    print(f"[PDF] {pdf_path} prêt.")
+
+###############################################################################
+# 5. DASH BLUEPRINT
+###############################################################################
+def run_dash(df):
+    app = dash.Dash(__name__)
+    app.layout = html.Div([
+        html.H2("MONSTERDOG – Anomalies Décortificum"),
+        dash_table.DataTable(
+            id='table', data=df.to_dict('records'), page_size=15,
+            style_cell={'textAlign': 'left'}
+        ),
+        dcc.Graph(id='zgraph'),
+        dcc.Interval(id='refresh', interval=60_000, n_intervals=0)
+    ])
+
+    @app.callback(Output('zgraph', 'figure'), Input('refresh', 'n_intervals'))
+    def update_graph(_):
+        zn = np.abs(stats.zscore(df.select_dtypes(include=np.number), nan_policy='omit'))
+        fig = {
+            'data': [{'y': zn.flatten(), 'type': 'scatter', 'mode': 'markers'}],
+            'layout': {'title': 'Distribution des |Z|'}
+        }
+        return fig
+
+    webbrowser.open("http://127.0.0.1:8050")
+    app.run_server(debug=False)
+
+###############################################################################
+# 6. BOUCLE « TRIPLE » & LANCEMENT
+###############################################################################
+def main():
+    base = load_metrics()
+    anomalies1 = extract_anomalies(base)
+    anomalies2 = extract_anomalies(pd.concat([base, base]))
+    anomalies3 = extract_anomalies(pd.concat([base]*3))
+
+    all_anoms = pd.concat([anomalies1, anomalies2, anomalies3]).drop_duplicates()
+    build_pdf(all_anoms)
+    print(f"[CSV] anomalies.csv exporté – {len(all_anoms)} lignes.")
+    run_dash(all_anoms)
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/flask_nft_interface.py
+++ b/scripts/flask_nft_interface.py
@@ -1,0 +1,218 @@
+"""
+FLASK + DASH NFT INTERFACE — MONSTERDOG TOTALITY EDITION v2
+=========================================================
+• Real IPFS pin via `ipfshttpclient` (or Pinata JWT fallback)
+• Signed ERC‑721 mint via `web3.py`
+• Fractal QR generation
+• Embedded Dash *Vortex* viewer (Plotly 3‑D)
+• Dockerfile & docker‑compose specs included below
+
+Install dependencies (`pip install -r requirements.txt`):
+    flask qrcode pillow ipfshttpclient web3 dash plotly
+Set the environment variables listed below before launch.
+"""
+from __future__ import annotations
+import io, json, os, tempfile, datetime as dt
+from pathlib import Path
+
+import qrcode
+from flask import Flask, request, send_file, url_for
+
+# 3rd‑party runtime deps (heavy — import lazily where possible)
+import ipfshttpclient  # communicates with local IPFS daemon
+from web3 import Web3, HTTPProvider
+from web3.middleware import geth_poa_middleware
+
+# ── Dash (Vortex visual) ───────────────────────────────────────────
+import dash
+from dash import html, dcc
+import plotly.graph_objects as go
+
+###############################################################################
+# 0. CONFIGURATION ────────────────────────────────────────────────────────────
+###############################################################################
+UPLOAD_DIR = Path(tempfile.gettempdir()) / "monsterdog_uploads"
+UPLOAD_DIR.mkdir(exist_ok=True)
+
+# ENV (secrets / infra)
+IPFS_API               = os.getenv("IPFS_API", "/ip4/127.0.0.1/tcp/5001")
+PINATA_JWT             = os.getenv("PINATA_JWT")
+WEB3_URI               = os.getenv("WEB3_PROVIDER_URI", "https://rpc.ankr.com/eth")
+CONTRACT_ADDRESS       = os.getenv("CONTRACT_ADDRESS", "0xYourContract")
+CONTRACT_ABI_JSON      = os.getenv("CONTRACT_ABI_JSON", "[]")  # stringified ABI
+WALLET_PRIVATE_KEY     = os.getenv("WALLET_PRIVATE_KEY", "")
+WALLET_ADDRESS         = os.getenv("WALLET_PUBLIC_ADDRESS", "0xYourWallet")
+
+###############################################################################
+# 1. HELPERS ──────────────────────────────────────────────────────────────────
+###############################################################################
+
+def upload_to_ipfs(path: Path) -> str:
+    """Pin via local IPFS daemon or Pinata JWT."""
+    if PINATA_JWT:
+        import requests
+        url = "https://api.pinata.cloud/pinning/pinFileToIPFS"
+        with path.open("rb") as fp:
+            files = {"file": fp}
+            headers = {"Authorization": f"Bearer {PINATA_JWT}"}
+            r = requests.post(url, files=files, headers=headers, timeout=120)
+        r.raise_for_status()
+        cid = r.json()["IpfsHash"]
+    else:
+        with ipfshttpclient.connect(IPFS_API) as cli:
+            cid = cli.add(str(path))["Hash"]
+    return f"ipfs://{cid}"
+
+
+def mint_nft(token_uri: str) -> str:
+    """Send `createNFT(tokenURI)` TX → returns TX hash."""
+    if not WALLET_PRIVATE_KEY:
+        raise RuntimeError("WALLET_PRIVATE_KEY absent – set env var")
+
+    w3 = Web3(HTTPProvider(WEB3_URI))
+    if "poa" in WEB3_URI:
+        w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    contract = w3.eth.contract(address=Web3.toChecksumAddress(CONTRACT_ADDRESS),
+                               abi=json.loads(CONTRACT_ABI_JSON))
+
+    tx = contract.functions.createNFT(token_uri).build_transaction({
+        "from": WALLET_ADDRESS,
+        "nonce": w3.eth.get_transaction_count(WALLET_ADDRESS),
+        "gas": 300_000,
+        "gasPrice": w3.eth.gas_price,
+    })
+    signed = w3.eth.account.sign_transaction(tx, private_key=WALLET_PRIVATE_KEY)
+    tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+    return w3.to_hex(tx_hash)
+
+
+def make_qr_bytes(data: str) -> bytes:
+    img = qrcode.make(data)
+    buf = io.BytesIO(); img.save(buf, format="PNG"); buf.seek(0); return buf.read()
+
+###############################################################################
+# 2. DASH VORTEX VISUAL ──────────────────────────────────────────────────────
+###############################################################################
+
+def build_vortex_fig():
+    import numpy as np
+    theta = np.linspace(0, 8 * np.pi, 512)
+    z = np.linspace(-2, 2, 512)
+    r = np.linspace(0.1, 1.2, 512)
+    x = r * np.cos(theta); y = r * np.sin(theta)
+    return go.Figure(go.Scatter3d(x=x, y=y, z=z,
+                                  mode='lines', line=dict(width=2)))
+
+app = Flask(__name__)
+
+# Embed Dash on /vortex/ prefix
+_dash = dash.Dash(__name__, server=app, routes_pathname_prefix="/vortex/")
+_dash.layout = html.Div([
+    html.H3("MONSTERDOG – Vortex Viewer", className="text-white"),
+    dcc.Graph(figure=build_vortex_fig())
+])
+
+###############################################################################
+# 3. TEMPLATES ───────────────────────────────────────────────────────────────
+###############################################################################
+BASE_TPL = """<!doctype html><html class='h-full' lang='en'>
+<head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<script src='https://cdn.tailwindcss.com'></script><title>MONSTERDOG NFT</title></head>
+<body class='bg-zinc-900 text-zinc-100 flex flex-col items-center py-12 min-h-full'>
+<h1 class='text-3xl font-bold mb-8'>MONSTERDOG ✶ NFT Mint</h1>{body}</body></html>"""
+
+INDEX_TPL = """<form class='flex flex-col gap-4 w-full max-w-md' action='{mint_url}' method='post' enctype='multipart/form-data'>
+<input name='title' placeholder='Titre' required class='p-3 rounded bg-zinc-800'>
+<textarea name='description' placeholder='Description' required class='p-3 rounded bg-zinc-800'></textarea>
+<input type='file' name='asset' accept='image/*' required class='file:bg-indigo-600 file:text-white file:px-4 file:py-2 file:rounded'>
+<button class='bg-indigo-600 hover:bg-indigo-500 rounded py-2 font-semibold'>Mint</button></form>"""
+
+RESULT_TPL = """<div class='bg-zinc-800 p-6 rounded-lg shadow-lg w-full max-w-xl flex flex-col gap-4'>
+<h2 class='text-xl font-semibold'>NFT Minté !</h2>
+<p><strong>Token URI :</strong> <a class='text-indigo-400 underline' href='{uri}' target='_blank'>{uri}</a></p>
+<p><strong>Transaction :</strong> <code>{tx}</code></p>
+<img class='mt-4 h-44 mx-auto' src='{qr_url}' alt='QR'>
+<a class='mt-6 bg-indigo-600 hover:bg-indigo-500 text-center rounded py-2 font-semibold' href='/'>← Nouveau mint</a></div>"""
+
+###############################################################################
+# 4. ROUTES ─────────────────────────────────────────────────────────────────--
+###############################################################################
+
+@app.route("/")
+def index():
+    return BASE_TPL.format(body=INDEX_TPL.format(mint_url=url_for('mint')))
+
+@app.route("/mint", methods=["POST"])
+def mint():
+    f = request.files.get("asset")
+    if not f:
+        return "No file", 400
+    filepath = UPLOAD_DIR / f"{dt.datetime.utcnow().strftime('%Y%m%dT%H%M%S')}_{f.filename}"
+    f.save(filepath)
+
+    # IPFS
+    asset_uri = upload_to_ipfs(filepath)
+    meta = {
+        "name": request.form.get("title", "Artwork"),
+        "description": request.form.get("description", ""),
+        "image": asset_uri,
+        "timestamp": dt.datetime.utcnow().isoformat(),
+    }
+    meta_file = filepath.with_suffix('.json'); meta_file.write_text(json.dumps(meta))
+    token_uri = upload_to_ipfs(meta_file)
+
+    # Mint
+    tx_hash = mint_nft(token_uri)
+
+    # QR
+    qr_bytes = make_qr_bytes(token_uri)
+    qr_name = f"qr_{meta_file.stem}.png"; (UPLOAD_DIR / qr_name).write_bytes(qr_bytes)
+    body = RESULT_TPL.format(uri=token_uri, tx=tx_hash, qr_url=url_for('qr', name=qr_name))
+    return BASE_TPL.format(body=body)
+
+@app.route("/qr/<name>")
+def qr(name):
+    p = UPLOAD_DIR / name
+    return send_file(p, mimetype="image/png") if p.exists() else ("404", 404)
+
+###############################################################################
+# 5. ENTRY POINT ─────────────────────────────────────────────────────────────
+###############################################################################
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+
+###############################################################################
+# 6. DOCKER & COMPOSE (SAVE AS SEPARATE FILES) ─────────────────────────────--
+###############################################################################
+
+DOCKERFILE = """
+# Dockerfile – MonsterDog NFT Interface
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir flask qrcode pillow ipfshttpclient web3 dash plotly
+ENV PORT=5000
+EXPOSE 5000
+CMD ["python", "flask_nft_interface.py"]
+"""
+
+DOCKER_COMPOSE = """
+version: '3.9'
+services:
+  nft-interface:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      - WEB3_PROVIDER_URI=https://rpc.ankr.com/eth_sepolia
+      - CONTRACT_ADDRESS=0x...
+      - CONTRACT_ABI_JSON=[...]  # paste ABI here
+      - WALLET_PRIVATE_KEY=${WALLET_PRIVATE_KEY}
+      - WALLET_PUBLIC_ADDRESS=${WALLET_PUBLIC_ADDRESS}
+    volumes:
+      - ./uploads:/tmp/monsterdog_uploads
+    depends_on: []
+"""
+
+


### PR DESCRIPTION
## Summary
- add Flask-based NFT mint interface with IPFS, Web3 and Dash viewer
- add metrics pipeline generating PDF reports and launching Dash dashboard
- document the new utilities in README
- remove unused import from NFT interface

## Testing
- `python -m py_compile scripts/MONSTERDOG_METRICS_ULTIMATE_TRIPLED.py scripts/flask_nft_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68416bc01428832b99dfaf7ddde2f548